### PR TITLE
github CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 
 # Prevent unreviewed lock files beign merge to main.  
-/tutorials/**/builderdao.lock.json  @TheBuilderDAO/reviewer
+/tutorials/**/builderdao.lock.json  @TheBuilderDAO/reviewers


### PR DESCRIPTION
@silentlight @dgamboa  we will need to create GitHub user teams to be set up nicely tuned. [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)  in order to add an extra layer of protection for security high impact files/folders.

at the state, I set;
`@TheBuilderDAO/core` = core team.
`@TheBuilderDAO/reviewers` = reviewers team.  

- [ ] create team for core team.
- [ ] create team for reviewers