### PR TITLE
Add footer divider before Authors component

### DIFF
--- a/apps/docs/pages/api-docs/algolia.mdx
+++ b/apps/docs/pages/api-docs/algolia.mdx
@@ -42,4 +42,6 @@ async updateTutorial(objectID: string, record: Partial<TutorialIndex>) {}
 }
 ```
 
+---
+
 <Authors path="apps/docs/pages/api-docs/algolia.mdx" />

--- a/apps/docs/pages/api-docs/arweave.mdx
+++ b/apps/docs/pages/api-docs/arweave.mdx
@@ -20,4 +20,6 @@ import Authors, { Author } from '@app/components/authors';
 
 ```
 
+---
+
 <Authors path="apps/docs/pages/api-docs/arweave.mdx" />

--- a/apps/docs/pages/api-docs/ceramic.mdx
+++ b/apps/docs/pages/api-docs/ceramic.mdx
@@ -20,4 +20,6 @@ import Authors, { Author } from '@app/components/authors';
 
 ```
 
+---
+
 <Authors path="apps/docs/pages/api-docs/ceramic.mdx" />

--- a/apps/docs/pages/api-docs/github.mdx
+++ b/apps/docs/pages/api-docs/github.mdx
@@ -20,4 +20,6 @@ import Authors, { Author } from '@app/components/authors';
 
 ```
 
+---
+
 <Authors path="apps/docs/pages/api-docs/github.mdx" />

--- a/apps/docs/pages/api-docs/solana.mdx
+++ b/apps/docs/pages/api-docs/solana.mdx
@@ -20,4 +20,6 @@ import Authors, { Author } from '@app/components/authors';
 
 ```
 
+---
+
 <Authors path="apps/docs/pages/api-docs/solana.mdx" />

--- a/apps/docs/pages/api-docs/typescript-sdk.mdx
+++ b/apps/docs/pages/api-docs/typescript-sdk.mdx
@@ -20,4 +20,6 @@ import Authors, { Author } from '@app/components/authors';
 
 ```
 
+---
+
 <Authors path="apps/docs/pages/api-docs/typescript-sdk.mdx" />

--- a/apps/docs/pages/builderdao-cli.mdx
+++ b/apps/docs/pages/builderdao-cli.mdx
@@ -24,4 +24,6 @@ import Authors, { Author } from '@app/components/authors';
 
 - template
 
+---
+
 <Authors path="apps/docs/pages/builderdao-cli.mdx" />

--- a/apps/docs/pages/digital-architecture/how-kafe-serves-content.mdx
+++ b/apps/docs/pages/digital-architecture/how-kafe-serves-content.mdx
@@ -26,4 +26,6 @@ The production environment is where the content is published to and retrieved fr
 
 {/* TODO: add links to publishing flow. */}
 
+---
+
 <Authors path="apps/docs/pages/digital-architecture/how-kafe-serves-content.mdx" />

--- a/apps/docs/pages/digital-architecture/summary.mdx
+++ b/apps/docs/pages/digital-architecture/summary.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Digital Architecture
 
+---
+
 <Authors path="apps/docs/pages/digital-architecture/summary.mdx" />

--- a/apps/docs/pages/github-actions/airdrop-solana.mdx
+++ b/apps/docs/pages/github-actions/airdrop-solana.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - airdrop-solana
 
+---
+
 <Authors path="apps/docs/pages/github-actions/airdrop-solana.mdx" />

--- a/apps/docs/pages/github-actions/build-builderdao-cli.mdx
+++ b/apps/docs/pages/github-actions/build-builderdao-cli.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - build-builderdao-cli
 
+---
+
 <Authors path="apps/docs/pages/github-actions/build-builderdao-cli.mdx" />

--- a/apps/docs/pages/github-actions/build-tutorial.mdx
+++ b/apps/docs/pages/github-actions/build-tutorial.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - build-tutorial
 
+---
+
 <Authors path="apps/docs/pages/github-actions/build-tutorial.mdx" />

--- a/apps/docs/pages/github-actions/check-required-reviewer.mdx
+++ b/apps/docs/pages/github-actions/check-required-reviewer.mdx
@@ -49,4 +49,6 @@ If the `$AUTHOR` is not in the list of the pull request reviews, we will return 
     value: ${{ steps.result.outputs.state }}
 ```
 
+---
+
 <Authors path="apps/docs/pages/github-actions/check-required-reviewer.mdx" />

--- a/apps/docs/pages/github-actions/install-anchor-version-manager.mdx
+++ b/apps/docs/pages/github-actions/install-anchor-version-manager.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-anchor-version-manager
 
+---
+
 <Authors path="apps/docs/pages/github-actions/install-anchor-version-manager.mdx" />

--- a/apps/docs/pages/github-actions/install-anchor.mdx
+++ b/apps/docs/pages/github-actions/install-anchor.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-anchor
 
+---
+
 <Authors path="apps/docs/pages/github-actions/install-anchor.mdx" />

--- a/apps/docs/pages/github-actions/install-linux-build-deps.mdx
+++ b/apps/docs/pages/github-actions/install-linux-build-deps.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-linux-build-deps
 
+---
+
 <Authors path="apps/docs/pages/github-actions/install-linux-build-deps.mdx" />

--- a/apps/docs/pages/github-actions/install-node-dependencies.mdx
+++ b/apps/docs/pages/github-actions/install-node-dependencies.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-node-dependencies
 
+---
+
 <Authors path="apps/docs/pages/github-actions/install-node-dependencies.mdx" />

--- a/apps/docs/pages/github-actions/install-rust.mdx
+++ b/apps/docs/pages/github-actions/install-rust.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-rust
 
+---
+
 <Authors path="apps/docs/pages/github-actions/install-rust.mdx" />

--- a/apps/docs/pages/github-actions/install-solana.mdx
+++ b/apps/docs/pages/github-actions/install-solana.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-solana
 
+---
+
 <Authors path="apps/docs/pages/github-actions/install-solana.mdx" />

--- a/apps/docs/pages/github-actions/test-tutorial.mdx
+++ b/apps/docs/pages/github-actions/test-tutorial.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - test-tutorial
 
+---
+
 <Authors path="apps/docs/pages/github-actions/test-tutorial.mdx" />

--- a/apps/docs/pages/github-actions/upsert-keypair.mdx
+++ b/apps/docs/pages/github-actions/upsert-keypair.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - upsert-keypair
 
+---
+
 <Authors path="apps/docs/pages/github-actions/upsert-keypair.mdx" />

--- a/apps/docs/pages/github-workflows/labeler.mdx
+++ b/apps/docs/pages/github-workflows/labeler.mdx
@@ -21,4 +21,6 @@ docs:
   - any: ['apps/docs/**/*']
 ```
 
+---
+
 <Authors path="apps/docs/pages/github-workflows/labeler.mdx" />

--- a/apps/docs/pages/github-workflows/program-tutorial.mdx
+++ b/apps/docs/pages/github-workflows/program-tutorial.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Workflows - program-tutorial
 
+---
+
 <Authors path="apps/docs/pages/github-workflows/program-tutorial.mdx" />

--- a/apps/docs/pages/github-workflows/proposal-index.mdx
+++ b/apps/docs/pages/github-workflows/proposal-index.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '../../components/authors';
 
 # GitHub Workflows - proposal-index
 
+---
+
 <Authors path="apps/docs/pages/github-workflows/proposal-index.mdx" />

--- a/apps/docs/pages/github-workflows/proposal-review.mdx
+++ b/apps/docs/pages/github-workflows/proposal-review.mdx
@@ -144,4 +144,6 @@ This leverages the github-script action to use the GitHub API to request reviewe
       });
 ```
 
+---
+
 <Authors path="apps/docs/pages/github-workflows/proposal-review.mdx" />

--- a/apps/docs/pages/github-workflows/publish.mdx
+++ b/apps/docs/pages/github-workflows/publish.mdx
@@ -79,4 +79,6 @@ There are a few variables that we need to pass to the publish job. The environme
 
 The internals of `builderdao tutorial publish $SLUG` is explained here.
 
+---
+
 <Authors path="apps/docs/pages/github-workflows/publish.mdx" />

--- a/apps/docs/pages/governance/summary.mdx
+++ b/apps/docs/pages/governance/summary.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Governance Summary
 
+---
+
 <Authors path="apps/docs/pages/governance/summary.mdx" />

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -1,9 +1,15 @@
 import Authors, { Author } from '@app/components/authors';
 
-# Builder DAO Documentation
+# What is the Builder DAO?
 
-- Navigate the documentation via the Table of Contents on the left.
+Builder DAO is a community of developers and builders learning together and collaborating in web3.
 
-## What is the Builder DAO?
+## What is Kafé?
+
+Kafé is a decentralized learning platform that incentivises great content and involves the community in the content creation and curation process.
+
+Visit [the Kafé site](https://dev.builderdao.io) to view the existing guides, vote on proposals made by community members, or submit your own proposal.
+
+---
 
 <Authors path="apps/docs/pages/index.mdx" />

--- a/apps/docs/pages/legal-architecture/limited-liability.mdx
+++ b/apps/docs/pages/legal-architecture/limited-liability.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Limited Liability
 
+---
+
 <Authors path="apps/docs/pages/legal-architecture/limited-liability.mdx" />

--- a/apps/docs/pages/legal-architecture/operating-agreement.mdx
+++ b/apps/docs/pages/legal-architecture/operating-agreement.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Operating Agreement
 
+---
+
 <Authors path="apps/docs/pages/legal-architecture/operating-agreement.mdx" />

--- a/apps/docs/pages/legal-architecture/organization-structure.mdx
+++ b/apps/docs/pages/legal-architecture/organization-structure.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Organization Structure
 
+---
+
 <Authors path="apps/docs/pages/legal-architecture/organization-structure.mdx" />

--- a/apps/docs/pages/legal-architecture/tax-considerations.mdx
+++ b/apps/docs/pages/legal-architecture/tax-considerations.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Tax Considerations
 
+---
+
 <Authors path="apps/docs/pages/legal-architecture/tax-considerations.mdx" />

--- a/apps/docs/pages/membership/core-membership.mdx
+++ b/apps/docs/pages/membership/core-membership.mdx
@@ -11,4 +11,6 @@ The current Core Members of Builder DAO are:
 - [Solana](https://solana.com)
 - [The Graph](https://thegraph.com)
 
+---
+
 <Authors path="apps/docs/pages/membership/core-membership.mdx" />

--- a/apps/docs/pages/membership/individual-membership.mdx
+++ b/apps/docs/pages/membership/individual-membership.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Individual Membership
 
+---
+
 <Authors path="apps/docs/pages/membership/individual-membership.mdx" />

--- a/apps/docs/pages/products/kafe/earning-rewards.mdx
+++ b/apps/docs/pages/products/kafe/earning-rewards.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Earning Rewards
 
+---
+
 <Authors path="apps/docs/pages/products/kafe/earning-rewards.mdx" />

--- a/apps/docs/pages/products/kafe/how-it-works.mdx
+++ b/apps/docs/pages/products/kafe/how-it-works.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # How It Works
 
+---
+
 <Authors path="apps/docs/pages/products/kafe/how-it-works.mdx" />

--- a/apps/docs/pages/products/kafe/overview.mdx
+++ b/apps/docs/pages/products/kafe/overview.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Overview
 
+---
+
 <Authors path="apps/docs/pages/products/kafe/overview.mdx" />

--- a/apps/docs/pages/products/kafe/technology-stack.mdx
+++ b/apps/docs/pages/products/kafe/technology-stack.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Technology Stack
 
+---
+
 <Authors path="apps/docs/pages/products/kafe/technology-stack.mdx" />

--- a/apps/docs/pages/products/kafe/webapp-docs.mdx
+++ b/apps/docs/pages/products/kafe/webapp-docs.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Kafé Web App Documentation
 
+---
+
 <Authors path="apps/docs/pages/products/kafe/webapp-docs.mdx" />

--- a/apps/docs/pages/tokenomics/builder-token.mdx
+++ b/apps/docs/pages/tokenomics/builder-token.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # BDR Token
 
+---
+
 <Authors path="apps/docs/pages/tokenomics/builder-token.mdx" />

--- a/apps/docs/pages/tokenomics/dual-token-system.mdx
+++ b/apps/docs/pages/tokenomics/dual-token-system.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # Dual Token System
 
+---
+
 <Authors path="apps/docs/pages/tokenomics/dual-token-system.mdx" />

--- a/apps/docs/pages/tokenomics/kafe-token.mdx
+++ b/apps/docs/pages/tokenomics/kafe-token.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # KAFE Token
 
+---
+
 <Authors path="apps/docs/pages/tokenomics/kafe-token.mdx" />

--- a/apps/docs/pages/typescript-sdk.mdx
+++ b/apps/docs/pages/typescript-sdk.mdx
@@ -2,4 +2,6 @@ import Authors, { Author } from '@app/components/authors';
 
 # TypeScript SDK
 
+---
+
 <Authors path="apps/docs/pages/typescript-sdk.mdx" />


### PR DESCRIPTION
- Add a divider before the Authors component on all current files, this serves as a footer area separate from the contents of the document. Mentioned in the [Style Guide](https://builderdao.notion.site/Kaf-Docs-Style-Guide-fa2e0ce252d444dcbb6ed70d44038d6d).
- Update the docs Index
<img width="1261" alt="Screen Shot 2022-05-02 at 3 26 22 PM" src="https://user-images.githubusercontent.com/2707197/166330397-82331d2a-2d8f-48bd-889c-a35301f2e316.png">

