### PR TITLE
Add title frontmatter to all docs

### DIFF
--- a/apps/docs/pages/api-docs/algolia.mdx
+++ b/apps/docs/pages/api-docs/algolia.mdx
@@ -1,3 +1,7 @@
+---
+title: Algolia API
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Algolia API documentation

--- a/apps/docs/pages/api-docs/arweave.mdx
+++ b/apps/docs/pages/api-docs/arweave.mdx
@@ -1,3 +1,7 @@
+---
+title: Arweave API
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Arweave API documentation

--- a/apps/docs/pages/api-docs/ceramic.mdx
+++ b/apps/docs/pages/api-docs/ceramic.mdx
@@ -1,3 +1,7 @@
+---
+title: Ceramic API
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Ceramic API documentation

--- a/apps/docs/pages/api-docs/github.mdx
+++ b/apps/docs/pages/api-docs/github.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub API
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # GitHub API documentation

--- a/apps/docs/pages/api-docs/solana.mdx
+++ b/apps/docs/pages/api-docs/solana.mdx
@@ -1,3 +1,7 @@
+---
+title: Solana API
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Solana API documentation

--- a/apps/docs/pages/api-docs/typescript-sdk.mdx
+++ b/apps/docs/pages/api-docs/typescript-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: TypeScript SDK
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Kafé TypeScript SDK

--- a/apps/docs/pages/builderdao-cli/meta.json
+++ b/apps/docs/pages/builderdao-cli/meta.json
@@ -1,0 +1,4 @@
+{
+  "summary": "Summary",
+  "solana-airdrop": "Solana Airdrop"
+}

--- a/apps/docs/pages/builderdao-cli/solana-airdrop.mdx
+++ b/apps/docs/pages/builderdao-cli/solana-airdrop.mdx
@@ -1,13 +1,14 @@
+---
+title: Solana Airdrop
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # The airdop command
 
 The following guide shows you how to send $KAFE and $BDR tokens to alpha testnet users.
 
-<aside>
-  🚨 Please confirm with @Daniel Gamboa before sending tokens to non-Figment
-  addresses.
-</aside>
+🚨 Please confirm with Daniel Gamboa before sending tokens to non-Figment addresses.
 
 ## Prerequisites
 
@@ -101,7 +102,10 @@ $ builderdao admin airdrop --adminKp <bs58Secret> --address <bs58Pubkey> --onlyK
 
 ```text
 builderdao admin airdrop --adminKp <paste-your-private-key-here>
---address <paste-destination-public-address-here>\*\*
+--address <paste-destination-public-address-here>
+```
+
+```text
 ✔ signature: <some-signature-hash-if-the-transaction-was-successful>
 ```
 

--- a/apps/docs/pages/builderdao-cli/summary.mdx
+++ b/apps/docs/pages/builderdao-cli/summary.mdx
@@ -1,3 +1,7 @@
+---
+title: Builder DAO CLI
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Builder DAO CLI documentation
@@ -26,4 +30,4 @@ import Authors, { Author } from '@app/components/authors';
 
 ---
 
-<Authors path="apps/docs/pages/builderdao-cli.mdx" />
+<Authors path="apps/docs/pages/builderdao-cli/builderdao-cli.mdx" />

--- a/apps/docs/pages/digital-architecture/how-kafe-serves-content.mdx
+++ b/apps/docs/pages/digital-architecture/how-kafe-serves-content.mdx
@@ -1,3 +1,7 @@
+---
+title: How Kafé Serves Content
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # How Kafé serves content

--- a/apps/docs/pages/digital-architecture/summary.mdx
+++ b/apps/docs/pages/digital-architecture/summary.mdx
@@ -1,3 +1,7 @@
+---
+title: Digital Architecture
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Digital Architecture

--- a/apps/docs/pages/github-actions/airdrop-solana.mdx
+++ b/apps/docs/pages/github-actions/airdrop-solana.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - airdrop-solana

--- a/apps/docs/pages/github-actions/build-builderdao-cli.mdx
+++ b/apps/docs/pages/github-actions/build-builderdao-cli.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - build-builderdao-cli

--- a/apps/docs/pages/github-actions/build-tutorial.mdx
+++ b/apps/docs/pages/github-actions/build-tutorial.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - build-tutorial

--- a/apps/docs/pages/github-actions/check-required-reviewer.mdx
+++ b/apps/docs/pages/github-actions/check-required-reviewer.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - check-required-reviewer

--- a/apps/docs/pages/github-actions/install-anchor-version-manager.mdx
+++ b/apps/docs/pages/github-actions/install-anchor-version-manager.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-anchor-version-manager

--- a/apps/docs/pages/github-actions/install-anchor.mdx
+++ b/apps/docs/pages/github-actions/install-anchor.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-anchor

--- a/apps/docs/pages/github-actions/install-linux-build-deps.mdx
+++ b/apps/docs/pages/github-actions/install-linux-build-deps.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-linux-build-deps

--- a/apps/docs/pages/github-actions/install-node-dependencies.mdx
+++ b/apps/docs/pages/github-actions/install-node-dependencies.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-node-dependencies

--- a/apps/docs/pages/github-actions/install-rust.mdx
+++ b/apps/docs/pages/github-actions/install-rust.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-rust

--- a/apps/docs/pages/github-actions/install-solana.mdx
+++ b/apps/docs/pages/github-actions/install-solana.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - install-solana

--- a/apps/docs/pages/github-actions/test-tutorial.mdx
+++ b/apps/docs/pages/github-actions/test-tutorial.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - test-tutorial

--- a/apps/docs/pages/github-actions/upsert-keypair.mdx
+++ b/apps/docs/pages/github-actions/upsert-keypair.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Actions - upsert-keypair

--- a/apps/docs/pages/github-workflows/labeler.mdx
+++ b/apps/docs/pages/github-workflows/labeler.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Workflows - labeler

--- a/apps/docs/pages/github-workflows/program-tutorial.mdx
+++ b/apps/docs/pages/github-workflows/program-tutorial.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Workflows - program-tutorial

--- a/apps/docs/pages/github-workflows/proposal-index.mdx
+++ b/apps/docs/pages/github-workflows/proposal-index.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Workflows - proposal-index

--- a/apps/docs/pages/github-workflows/proposal-review.mdx
+++ b/apps/docs/pages/github-workflows/proposal-review.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '../../components/authors';
 
 # GitHub Workflows - proposal-review

--- a/apps/docs/pages/github-workflows/publish.mdx
+++ b/apps/docs/pages/github-workflows/publish.mdx
@@ -1,3 +1,7 @@
+---
+title: GitHub Actions
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # GitHub Workflows - publish

--- a/apps/docs/pages/governance/summary.mdx
+++ b/apps/docs/pages/governance/summary.mdx
@@ -1,3 +1,7 @@
+---
+title: Governance
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Governance Summary

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # What is the Builder DAO?

--- a/apps/docs/pages/legal-architecture/limited-liability.mdx
+++ b/apps/docs/pages/legal-architecture/limited-liability.mdx
@@ -1,3 +1,7 @@
+---
+title: Limited Liability
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Limited Liability

--- a/apps/docs/pages/legal-architecture/operating-agreement.mdx
+++ b/apps/docs/pages/legal-architecture/operating-agreement.mdx
@@ -1,3 +1,7 @@
+---
+title: Operating Agreement
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Operating Agreement

--- a/apps/docs/pages/legal-architecture/organization-structure.mdx
+++ b/apps/docs/pages/legal-architecture/organization-structure.mdx
@@ -1,3 +1,7 @@
+---
+title: Organization Structure
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Organization Structure

--- a/apps/docs/pages/legal-architecture/tax-considerations.mdx
+++ b/apps/docs/pages/legal-architecture/tax-considerations.mdx
@@ -1,3 +1,7 @@
+---
+title: Tax Considerations
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Tax Considerations

--- a/apps/docs/pages/membership/core-membership.mdx
+++ b/apps/docs/pages/membership/core-membership.mdx
@@ -1,3 +1,7 @@
+---
+title: Core Membership
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Core Membership

--- a/apps/docs/pages/membership/individual-membership.mdx
+++ b/apps/docs/pages/membership/individual-membership.mdx
@@ -1,3 +1,7 @@
+---
+title: Individual Membership
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Individual Membership

--- a/apps/docs/pages/products/kafe/earning-rewards.mdx
+++ b/apps/docs/pages/products/kafe/earning-rewards.mdx
@@ -1,3 +1,7 @@
+---
+title: Earning Rewards
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Earning Rewards

--- a/apps/docs/pages/products/kafe/how-it-works.mdx
+++ b/apps/docs/pages/products/kafe/how-it-works.mdx
@@ -1,3 +1,7 @@
+---
+title: How It Works
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # How It Works

--- a/apps/docs/pages/products/kafe/overview.mdx
+++ b/apps/docs/pages/products/kafe/overview.mdx
@@ -1,3 +1,7 @@
+---
+title: Kafé Overview
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Overview

--- a/apps/docs/pages/products/kafe/technology-stack.mdx
+++ b/apps/docs/pages/products/kafe/technology-stack.mdx
@@ -1,3 +1,7 @@
+---
+title: Technology Stack
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # Technology Stack

--- a/apps/docs/pages/products/kafe/webapp-docs.mdx
+++ b/apps/docs/pages/products/kafe/webapp-docs.mdx
@@ -1,6 +1,10 @@
+---
+title: Kafé Web App
+---
+
 import Authors, { Author } from '@app/components/authors';
 
-# Kafé Web App Documentation
+# Kafé Web App documentation
 
 ---
 

--- a/apps/docs/pages/tokenomics/builder-token.mdx
+++ b/apps/docs/pages/tokenomics/builder-token.mdx
@@ -1,3 +1,7 @@
+---
+title: BDR Token
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # BDR Token

--- a/apps/docs/pages/tokenomics/kafe-token.mdx
+++ b/apps/docs/pages/tokenomics/kafe-token.mdx
@@ -1,3 +1,7 @@
+---
+title: KAFE Token
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # KAFE Token

--- a/apps/docs/pages/typescript-sdk.mdx
+++ b/apps/docs/pages/typescript-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: TypeScript SDK
+---
+
 import Authors, { Author } from '@app/components/authors';
 
 # TypeScript SDK


### PR DESCRIPTION
- Add title frontmatter to all docs pages. The [style guide](https://builderdao.notion.site/Kaf-Docs-Style-Guide-fa2e0ce252d444dcbb6ed70d44038d6d) was updated to include this.

```text
---
title: <title of page>
---
```

This prevents any pages from being "Untitled" by Nextra -> https://github.com/shuding/nextra/issues/235
<img width="530" alt="Screen Shot 2022-05-03 at 4 39 24 PM" src="https://user-images.githubusercontent.com/2707197/166584515-6fb1a26f-eb89-4f1b-91cb-7aa0398c35ac.png">
<img width="530" alt="Screen Shot 2022-05-03 at 4 40 53 PM" src="https://user-images.githubusercontent.com/2707197/166584735-971b16b0-1612-49ae-a62c-1b55d274e7be.png">

