### PR TITLE
add shell for github action

### DIFF
--- a/.github/actions/build-builderdao-cli/action.yaml
+++ b/.github/actions/build-builderdao-cli/action.yaml
@@ -10,19 +10,23 @@ runs:
         cache: 'yarn'
         cache-dependency-path: yarn.lock
     - name: Get yarn cache directory path
+      shell: bash
       id: yarn-cache-dir-path
       run: |
           echo "::set-output name=dir::$(yarn cache dir)"
 
     - name: Set yarn global bin path
+      shell: bash
       run: |
            yarn config set prefix $(yarn cache dir)
 
     - name: Add yarn bin path to system path
+      shell: bash
       run: |
            echo $(yarn global bin) >> $GITHUB_PATH
 
     - name: Set yarn global installation path
+      shell: bash
       run: |
            yarn config set global-folder $(yarn cache dir)
 


### PR DESCRIPTION
Solves the GitHub action error;
https://github.com/TheBuilderDAO/kafe/actions/runs/2421466053
```
home/runner/work/kafe/kafe/./.github/actions/build-builderdao-cli/action.yaml (Line: 12, Col: 7): Required property is missing: shell
```